### PR TITLE
fixing api response and spec

### DIFF
--- a/lib/handlers/default.rb
+++ b/lib/handlers/default.rb
@@ -5,6 +5,7 @@ module Handlers
       @raw_response = raw_response
       @success_response, @error_response = nil
       error_occured? ? (@error_response=@raw_response.body) : (@success_response=@raw_response.body)
+      @success_response=@raw_response.body
     end
 
     def value

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -27,7 +27,7 @@ describe Service do
       configure_api
       response = service.sample
 
-      headers = {"content-type":"application/json"}
+      headers = {"content-type" => "application/json"}
       url = "http://requestb.in/sample"
       expect(WebMock).to have_requested(:get, url).with(headers: headers).once
       expect(response.value).to eq("abc")

--- a/spec/unit/web_api_spec.rb
+++ b/spec/unit/web_api_spec.rb
@@ -79,7 +79,7 @@ describe WebApi do
     it "should be interpolated with passed in hash to dynamically poplate values" do
       api = WebApi.new(global_config).init("sample", "/sample/%{id}/%{name}") { method :get }
 
-      expect(api.url({id: "1", "name": "twilo"})).to eq("/sample/1/twilo")
+      expect(api.url({"id"=> "1", "name"=> "twilo"})).to eq("/sample/1/twilo")
     end
 
   end
@@ -113,10 +113,10 @@ describe WebApi do
     end
 
     it "should merge headers with global headers" do
-      global_config.add_config("headers", {"authorization": "OAuth 1234"})
+      global_config.add_config("headers", {"authorization"=> "OAuth 1234"})
 
       expect(api.http_headers).to include({:"content-type" => "application/json"})
-      expect(api.http_headers).to include({:authorization => "OAuth 1234"})
+      expect(api.http_headers).to include({"authorization"=>"OAuth 1234"})
     end
 
     it "from api config should override global header" do


### PR DESCRIPTION
These are the changes made for returning exact error responses from the DS API instead of 'null'.